### PR TITLE
Battleを開催中/終了/今後のコンテストの3つに分割する

### DIFF
--- a/src/components/screen/BattleListTable/BattleListTable.tsx
+++ b/src/components/screen/BattleListTable/BattleListTable.tsx
@@ -6,17 +6,23 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Battle } from "@/schema/Battle.type";
 import { Progress } from "@/components/ui/progress";
 import dayjs from "dayjs";
 import { useState, useEffect } from "react";
+import { ExclamationTriangleIcon, PieChartIcon } from "@radix-ui/react-icons";
 
 type BattleListTableProps = {
-  battles: Battle[];
+  battles: Battle[] | null;
+  variant: "upcoming" | "running" | "recent";
+  isLoading: boolean;
 };
 
 export const BattleListTable: React.FC<BattleListTableProps> = ({
   battles,
+  variant,
+  isLoading,
 }: BattleListTableProps) => {
   const [isSP, setIsSP] = useState(false);
   useEffect(() => {
@@ -26,66 +32,93 @@ export const BattleListTable: React.FC<BattleListTableProps> = ({
   }, []);
 
   return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead>Title</TableHead>
-          {!isSP && (
-            <>
-              <TableHead>Description</TableHead>
-              <TableHead className="text-center">No. of Teams</TableHead>
-            </>
-          )}
-          <TableHead className="text-center">Duration</TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {battles.map((battle) => {
-          const progressPercentage = Math.floor(
-            ((new Date().getTime() - battle.startDate) /
-              (battle.endDate - battle.startDate)) *
-              100,
-          );
+    <>
+      <h1 className="border-b border-gray-300 text-2xl font-semibold">
+        {variant.charAt(0).toUpperCase() + variant.slice(1)} Battles
+      </h1>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Title</TableHead>
+            {!isSP && (
+              <>
+                <TableHead>Description</TableHead>
+                <TableHead className="text-center">No. of Teams</TableHead>
+              </>
+            )}
+            <TableHead className="text-center">Duration</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {battles ? (
+            battles.map((battle) => {
+              const progressPercentage = Math.floor(
+                ((new Date().getTime() - battle.startDate) /
+                  (battle.endDate - battle.startDate)) *
+                  100,
+              );
 
-          return (
-            <TableRow
-              key={battle.id}
-              className="cursor-pointer hover:bg-gray-200"
-            >
-              <TableCell className="w-1/5 font-semibold">
-                {battle.title}
-              </TableCell>
-              {!isSP && (
-                <>
-                  <TableCell className="w-1/3">
-                    <p className="line-clamp-2">{battle.description}</p>
+              return (
+                <TableRow
+                  key={battle.id}
+                  className="cursor-pointer hover:bg-gray-200"
+                >
+                  <TableCell className="w-1/5 font-semibold">
+                    {battle.title}
                   </TableCell>
-                  <TableCell className="w-1/5 text-center">
-                    {battle.scores.length} Teams
+                  {!isSP && (
+                    <>
+                      <TableCell className="w-1/3">
+                        <p className="line-clamp-2">{battle.description}</p>
+                      </TableCell>
+                      <TableCell className="w-1/5 text-center">
+                        {battle.scores.length} Teams
+                      </TableCell>
+                    </>
+                  )}
+                  <TableCell className="flex flex-col gap-1">
+                    <div className="flex justify-between text-sm">
+                      <div className="font-thin">
+                        <p>{dayjs(battle.startDate).format("YYYY MM DD")}</p>
+                        <p>{dayjs(battle.startDate).format("HH:mm")}</p>
+                      </div>
+                      <div className="text-right font-thin">
+                        <p>{dayjs(battle.endDate).format("YYYY MM DD")}</p>
+                        <p>{dayjs(battle.endDate).format("HH:mm")}</p>
+                      </div>
+                    </div>
+                    <Progress
+                      value={progressPercentage}
+                      className="bg-emerald-300"
+                    />
                   </TableCell>
-                </>
-              )}
-              <TableCell className="flex flex-col gap-1">
-                <div className="flex justify-between text-sm">
-                  <div className="font-thin">
-                    <p>{dayjs(battle.startDate).format("YYYY MM DD")}</p>
-                    <p>{dayjs(battle.startDate).format("HH:mm")}</p>
-                  </div>
-                  <div className="text-right font-thin">
-                    <p>{dayjs(battle.endDate).format("YYYY MM DD")}</p>
-                    <p>{dayjs(battle.endDate).format("HH:mm")}</p>
-                  </div>
-                </div>
-                <Progress
-                  value={progressPercentage}
-                  className="bg-emerald-300"
-                />
+                </TableRow>
+              );
+            })
+          ) : (
+            <TableRow>
+              <TableCell colSpan={isSP ? 2 : 4}>
+                {isLoading ? (
+                  <Alert>
+                    <ExclamationTriangleIcon />
+                    <AlertTitle>Loading</AlertTitle>
+                    <AlertDescription>
+                      <PieChartIcon className="animate-spin" />
+                    </AlertDescription>
+                  </Alert>
+                ) : (
+                  <Alert variant="destructive">
+                    <ExclamationTriangleIcon />
+                    <AlertTitle>Error</AlertTitle>
+                    <AlertDescription>Failed to fetch data</AlertDescription>
+                  </Alert>
+                )}
               </TableCell>
             </TableRow>
-          );
-        })}
-      </TableBody>
-    </Table>
+          )}
+        </TableBody>
+      </Table>
+    </>
   );
 };
 

--- a/src/components/screen/DashBoard/DashBoard.tsx
+++ b/src/components/screen/DashBoard/DashBoard.tsx
@@ -1,32 +1,42 @@
 import { Battle } from "@/schema/Battle.type";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { useMemo, useState } from "react";
-import { CaretSortIcon } from "@radix-ui/react-icons";
+import { CaretSortIcon, PieChartIcon } from "@radix-ui/react-icons";
 import { Button } from "@/components/ui/button";
 import clsx from "clsx";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
 
 type DashBoardProps = {
-  battles: Battle[];
+  battles: Battle[] | null;
+  isLoading: boolean;
 };
 
 export const DashBoard: React.FC<DashBoardProps> = ({
   battles,
+  isLoading,
 }: DashBoardProps) => {
   const activeTeams = useMemo(() => {
-    return battles.reduce((acc, battle) => {
-      return acc + battle.scores.length;
-    }, 0);
+    return (
+      battles &&
+      battles.reduce((acc, battle) => {
+        return acc + battle.scores.length;
+      }, 0)
+    );
   }, [battles]);
 
   const activeUsers = useMemo(() => {
-    return battles.reduce((acc, battle) => {
-      return (
-        acc +
-        battle.scores.reduce((acc, score) => {
-          return acc + score.userScore.length;
-        }, 0)
-      );
-    }, 0);
+    return (
+      battles &&
+      battles.reduce((acc, battle) => {
+        return (
+          acc +
+          battle.scores.reduce((acc, score) => {
+            return acc + score.userScore.length;
+          }, 0)
+        );
+      }, 0)
+    );
   }, [battles]);
 
   const [isOpen, setIsOpen] = useState(false);
@@ -39,34 +49,54 @@ export const DashBoard: React.FC<DashBoardProps> = ({
           <CaretSortIcon />
         </Button>
       </div>
-      <div
-        className={clsx(
-          "grid grid-cols-1 gap-4 sm:grid-cols-3",
-          isOpen ? "grid sm:hidden" : "hidden sm:grid",
-        )}
-      >
-        <Card>
-          <CardHeader className="text-sm">Running Battles</CardHeader>
-          <CardContent className="flex justify-center gap-2 text-xl font-bold sm:justify-start">
-            <p className="text-emerald-400">{battles.length}</p>
-            <p> Battles</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="text-sm">Active Teams</CardHeader>
-          <CardContent className="flex justify-center gap-2 text-xl font-bold sm:justify-start">
-            <p className="text-emerald-400"> {activeTeams}</p>
-            <p>Teams</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="text-sm">Active Users</CardHeader>
-          <CardContent className="flex justify-center gap-2 text-xl font-bold sm:justify-start">
-            <p className="text-emerald-400"> {activeUsers}</p>
-            <p>Users</p>
-          </CardContent>
-        </Card>
-      </div>
+      {battles ? (
+        <div
+          className={clsx(
+            "grid grid-cols-1 gap-4 sm:grid-cols-3",
+            isOpen ? "grid sm:hidden" : "hidden sm:grid",
+          )}
+        >
+          <Card>
+            <CardHeader className="text-sm">Running Battles</CardHeader>
+            <CardContent className="flex justify-center gap-2 text-xl font-bold sm:justify-start">
+              <p className="text-emerald-400">{battles.length}</p>
+              <p>Battles</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="text-sm">Active Teams</CardHeader>
+            <CardContent className="flex justify-center gap-2 text-xl font-bold sm:justify-start">
+              <p className="text-emerald-400"> {activeTeams}</p>
+              <p>Teams</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="text-sm">Active Users</CardHeader>
+            <CardContent className="flex justify-center gap-2 text-xl font-bold sm:justify-start">
+              <p className="text-emerald-400"> {activeUsers}</p>
+              <p>Users</p>
+            </CardContent>
+          </Card>
+        </div>
+      ) : (
+        <>
+          {isLoading ? (
+            <Alert>
+              <ExclamationTriangleIcon />
+              <AlertTitle>Loading</AlertTitle>
+              <AlertDescription>
+                <PieChartIcon className="animate-spin" />
+              </AlertDescription>
+            </Alert>
+          ) : (
+            <Alert variant="destructive">
+              <ExclamationTriangleIcon />
+              <AlertTitle>Error</AlertTitle>
+              <AlertDescription>Failed to fetch data</AlertDescription>
+            </Alert>
+          )}
+        </>
+      )}
     </div>
   );
 };

--- a/src/components/screen/Header/Header.tsx
+++ b/src/components/screen/Header/Header.tsx
@@ -11,7 +11,7 @@ export const Header: React.FC = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   return (
-    <header className="sticky top-0 flex items-center justify-between bg-gray-200/10 px-8 py-4  backdrop-blur-md">
+    <header className="sticky top-0 z-50 flex items-center justify-between bg-gray-200/10 px-8  py-4 backdrop-blur-md">
       <h1 className="text-xl font-bold sm:text-2xl">AtCoder Team Battle</h1>
       <div className="hidden gap-8 sm:flex">
         <Button variant="ghost" className="flex gap-2">

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,63 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border p-4 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+));
+Alert.displayName = "Alert";
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement> & {
+    className?: string;
+  }
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+AlertTitle.displayName = "AlertTitle";
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement> & {
+    className?: string;
+  }
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    {...props}
+  />
+));
+AlertDescription.displayName = "AlertDescription";
+
+export { Alert, AlertTitle, AlertDescription };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,17 +2,29 @@ import { Noto_Sans_JP } from "next/font/google";
 import BattleListTable from "@/components/screen/BattleListTable/BattleListTable";
 import { useState, useEffect } from "react";
 import { Battle } from "@/schema/Battle.type";
-import { createMockBattles } from "@/repositories/createMockBattle";
+import { createMockAllTimeBattle } from "@/repositories/createMockBattle";
 import { DashBoard } from "@/components/screen/DashBoard";
 
 const notoSansJP = Noto_Sans_JP({ subsets: ["latin"] });
 
 export default function Home() {
-  const [battles, setBattles] = useState<Battle[]>([]);
+  const [AllBattles, setAllBattles] = useState<{
+    upcoming: Battle[];
+    running: Battle[];
+    recent: Battle[];
+  }>();
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    const battles = createMockBattles(5);
-    setBattles(battles);
+    setIsLoading(true);
+    const { upcomingBattles, runningBattles, recentBattles } =
+      createMockAllTimeBattle();
+    setAllBattles({
+      upcoming: upcomingBattles,
+      running: runningBattles,
+      recent: recentBattles,
+    });
+    setIsLoading(false);
   }, []);
 
   return (
@@ -20,12 +32,26 @@ export default function Home() {
       className={`flex min-h-screen flex-col items-center gap-8 ${notoSansJP.className}`}
     >
       <div className="flex w-4/5 flex-col gap-8">
-        <DashBoard battles={battles} />
+        <DashBoard
+          battles={AllBattles?.running || null}
+          isLoading={isLoading}
+        />
         <div className="flex flex-col gap-4">
-          <h1 className="border-b border-gray-300 text-2xl font-semibold">
-            Battles
-          </h1>
-          <BattleListTable battles={battles} />
+          <BattleListTable
+            battles={AllBattles?.running || null}
+            variant="running"
+            isLoading={isLoading}
+          />
+          <BattleListTable
+            battles={AllBattles?.upcoming || null}
+            variant="upcoming"
+            isLoading={isLoading}
+          />
+          <BattleListTable
+            battles={AllBattles?.recent || null}
+            variant="recent"
+            isLoading={isLoading}
+          />
         </div>
       </div>
     </main>

--- a/src/repositories/createMockBattle.ts
+++ b/src/repositories/createMockBattle.ts
@@ -2,14 +2,27 @@ import { createMockScores } from "./createMockScore";
 import { Battle } from "@/schema/Battle.type";
 import { faker } from "@faker-js/faker";
 
-export const createMockBattle = (): Battle => {
+export const createMockBattle = ({
+  variant,
+}: {
+  variant?: "upcoming" | "recent" | "running";
+}): Battle => {
   const id = faker.string.uuid();
   const title = faker.company.name();
   const description = faker.lorem.paragraph();
   const scores = createMockScores(faker.number.int({ min: 3, max: 10 }));
-  const startDate = faker.date.past().getTime();
-  const endDate = faker.date.future().getTime();
   const createdAt = faker.date.past().getTime();
+
+  let startDate = faker.date.past().getTime();
+  let endDate = faker.date.future().getTime();
+
+  if (variant === "upcoming") {
+    endDate = faker.date.future().getTime();
+    startDate = faker.date.between(new Date(), endDate).getTime();
+  } else if (variant === "recent") {
+    startDate = faker.date.past().getTime();
+    endDate = faker.date.between(startDate, new Date()).getTime();
+  }
 
   return {
     id,
@@ -24,6 +37,37 @@ export const createMockBattle = (): Battle => {
   };
 };
 
-export const createMockBattles = (count: number): Battle[] => {
-  return Array.from({ length: count }, () => createMockBattle());
+export const createMockBattles = ({
+  count,
+  variant,
+}: {
+  count: number;
+  variant?: "upcoming" | "recent" | "running";
+}): Battle[] => {
+  return Array.from({ length: count }, () => createMockBattle({ variant }));
+};
+
+export const createMockAllTimeBattle = (): {
+  upcomingBattles: Battle[];
+  recentBattles: Battle[];
+  runningBattles: Battle[];
+} => {
+  const upcomingBattles = createMockBattles({
+    count: faker.number.int({ min: 3, max: 10 }),
+    variant: "upcoming",
+  });
+  const recentBattles = createMockBattles({
+    count: faker.number.int({ min: 3, max: 10 }),
+    variant: "recent",
+  });
+  const runningBattles = createMockBattles({
+    count: faker.number.int({ min: 3, max: 10 }),
+    variant: "running",
+  });
+
+  return {
+    upcomingBattles,
+    recentBattles,
+    runningBattles,
+  };
 };


### PR DESCRIPTION
# what

- Battlesを一つのテーブルで管理するのではなく、Upcoming / Running / Recentの3つのカテゴリに分割した

# how

- BattleListTableとMockデータの生成を3つのカテゴリに対応
- データ取得失敗/データ取得中の画面表示を追加

# test
- github actions