### PR TITLE
userページにそのユーザーが参加したBattle一覧を表示

### DIFF
--- a/src/components/screen/LoadingBattleBoard/LoadingBattleBoard.tsx
+++ b/src/components/screen/LoadingBattleBoard/LoadingBattleBoard.tsx
@@ -5,9 +5,7 @@ export const LoadingBattleBoard = () => {
   return (
     <div className="flex flex-col gap-8">
       <LoadingDashBoard />
-      <div className="flex flex-col gap-4">
-        <LoadingAlert />
-      </div>
+      <LoadingAlert />
     </div>
   );
 };

--- a/src/components/screen/LoadingUserProfileContent/LoadingUserProfileContent.tsx
+++ b/src/components/screen/LoadingUserProfileContent/LoadingUserProfileContent.tsx
@@ -1,7 +1,13 @@
+import { LoadingAlert } from "@/components/common/LoadingAlert";
 import LoadingUserProfileCard from "./components/LoadingUserProfileCard";
 
 export const LoadingUserProfileContent = () => {
-  return <LoadingUserProfileCard />;
+  return (
+    <div className="flex flex-col gap-8">
+      <LoadingUserProfileCard />
+      <LoadingAlert />
+    </div>
+  );
 };
 
 export default LoadingUserProfileContent;

--- a/src/components/screen/UserProfileContent/UserProfileContent.tsx
+++ b/src/components/screen/UserProfileContent/UserProfileContent.tsx
@@ -1,10 +1,18 @@
+import { createMockBattles } from "@/repositories/createMockBattle";
 import { createMockUser } from "../../../repositories/createMockUser";
 import { UserProfileCard } from "../UserProfileCard/UserProfileCard";
+import { BattleListTable } from "../BattleListTable";
 
 export const UserProfileContent = async () => {
   const user = await createMockUser();
+  const userBattle = await createMockBattles({ count: 5, variant: "recent" });
 
-  return <UserProfileCard user={user} />;
+  return (
+    <div className="flex flex-col gap-8">
+      <UserProfileCard user={user} />
+      <BattleListTable battles={userBattle} variant="recent" />
+    </div>
+  );
 };
 
 export default UserProfileContent;


### PR DESCRIPTION
# what

- ユーザーページに参加したBattle一覧のテーブルを表示するようにした

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタ**
  - `LoadingBattleBoard` コンポーネントから不要な `div` 要素を削除し、HTML要素のネストを減らし、コンポーネントの構造を簡素化しました。
  - `LoadingUserProfileContent` コンポーネントに `LoadingAlert` を追加し、より視覚的なフィードバックを提供するようにしました。

- **新機能**
  - `UserProfileContent` コンポーネントに新しい非同期関数を追加し、ユーザーとその最近のバトル情報を取得して表示します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->