### PR TITLE
ユーザー編集フォームにFormコンポーネントを適用

### DIFF
--- a/src/components/screen/UserProfileContent/components/EditUserProfileCard.tsx
+++ b/src/components/screen/UserProfileContent/components/EditUserProfileCard.tsx
@@ -1,25 +1,9 @@
 "use client";
 
-import { BIO_MAX_LENGTH, User } from "@/schema/User.type";
-import {
-  Card,
-  CardHeader,
-  CardContent,
-  CardFooter,
-  CardDescription,
-} from "@/components/ui/card";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import {
-  GitHubLogoIcon,
-  TwitterLogoIcon,
-  Link1Icon,
-} from "@radix-ui/react-icons";
-import { Button } from "@/components/ui/button";
-import { Skeleton } from "@/components/common/Skeleton";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
-import { useEditUserProfileForm } from "../hooks/useEditUserProfileForm";
-import { BioCounter } from "./BioCounter";
+import { User } from "@/schema/User.type";
+import { Card } from "@/components/ui/card";
+
+import { EditUserProfileForm } from "./EditUserProfileForm";
 
 export type EditUserProfileCardProps = {
   user: User;
@@ -28,156 +12,10 @@ export type EditUserProfileCardProps = {
 export const EditUserProfileCard: React.FC<EditUserProfileCardProps> = ({
   user,
 }: EditUserProfileCardProps) => {
-  const {
-    onSubmit,
-    register,
-    control,
-    isDirty,
-    isSubmitting,
-    isValid,
-    errors,
-  } = useEditUserProfileForm(user);
-
   return (
-    <form onSubmit={onSubmit}>
-      <Card>
-        <CardHeader>
-          <div className="flex items-center gap-4">
-            <Avatar className="h-16 w-16 border">
-              <AvatarImage src={user.icon} alt={user.name} />
-              <AvatarFallback>
-                <Skeleton className="h-16 w-16 rounded-full border" />
-              </AvatarFallback>
-            </Avatar>
-            <div className="flex flex-col gap-2">
-              <div className="flex items-center gap-2">
-                <Input
-                  required
-                  type="text"
-                  placeholder="AtCoder ID"
-                  {...register("atcoderId")}
-                />
-                {errors.atcoderId && (
-                  <p className="whitespace-nowrap text-sm text-red-500">
-                    {errors.atcoderId.message}
-                  </p>
-                )}
-              </div>
-              <div className="flex items-center gap-2">
-                <Input
-                  required
-                  type="text"
-                  placeholder="Name"
-                  {...register("name")}
-                />
-                {errors.name && (
-                  <p className="whitespace-nowrap text-sm text-red-500">
-                    {errors.name.message}
-                  </p>
-                )}
-              </div>
-            </div>
-          </div>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-4">
-          <div className="flex flex-col gap-2 md:flex-row md:items-center">
-            <Input
-              type="text"
-              placeholder="Occupation"
-              className="w-64"
-              {...register("occupation")}
-            />
-            <div className="flex items-center gap-2">
-              <p>at</p>
-              <Input
-                type="text"
-                placeholder="Organization"
-                className="w-64"
-                {...register("organization")}
-              />
-            </div>
-            {errors.occupation && (
-              <p className="whitespace-nowrap text-sm text-red-500">
-                {errors.occupation.message}
-              </p>
-            )}
-            {errors.organization && (
-              <p className="whitespace-nowrap text-sm text-red-500">
-                {errors.organization.message}
-              </p>
-            )}
-          </div>
-          <div className="flex flex-col items-end gap-1">
-            <Textarea placeholder="Bio" className="h-32" {...register("bio")} />
-            <BioCounter control={control}>
-              {(count) => (
-                <CardDescription className="text-sm">
-                  {count}/{BIO_MAX_LENGTH}
-                </CardDescription>
-              )}
-            </BioCounter>
-            {errors.bio && (
-              <p className="whitespace-nowrap text-sm text-red-500">
-                {errors.bio.message}
-              </p>
-            )}
-          </div>
-          <div className="flex flex-col gap-4">
-            <div className="flex items-center gap-4">
-              <GitHubLogoIcon className="h-6 w-6" />
-              <Input
-                type="text"
-                placeholder="GitHub"
-                className="w-72"
-                {...register("links.github")}
-              />
-              {errors.links?.github && (
-                <p className="whitespace-nowrap text-sm text-red-500">
-                  {errors.links.github.message}
-                </p>
-              )}
-            </div>
-            <div className="flex items-center gap-4">
-              <TwitterLogoIcon className="h-6 w-6" />
-              <Input
-                type="text"
-                placeholder="Twitter"
-                className="w-72"
-                {...register("links.twitter")}
-              />
-              {errors.links?.twitter && (
-                <p className="whitespace-nowrap text-sm text-red-500">
-                  {errors.links.twitter.message}
-                </p>
-              )}
-            </div>
-            <div className="flex items-center gap-4">
-              <Link1Icon className="h-6 w-6" />
-              <Input
-                type="text"
-                placeholder="Website"
-                className="w-72"
-                {...register("links.website")}
-              />
-              {errors.links?.website && (
-                <p className="whitespace-nowrap text-sm text-red-500">
-                  {errors.links.website.message}
-                </p>
-              )}
-            </div>
-          </div>
-        </CardContent>
-        <CardFooter>
-          <Button
-            type="submit"
-            className="ml-auto"
-            disabled={!isDirty || !isValid || isSubmitting}
-          >
-            Submit
-          </Button>
-        </CardFooter>
-      </Card>
-    </form>
+    <Card>
+      <EditUserProfileForm user={user} />
+    </Card>
   );
 };
 

--- a/src/components/screen/UserProfileContent/components/EditUserProfileForm.tsx
+++ b/src/components/screen/UserProfileContent/components/EditUserProfileForm.tsx
@@ -1,0 +1,218 @@
+import { BIO_MAX_LENGTH, User } from "@/schema/User.type";
+import {
+  CardHeader,
+  CardContent,
+  CardFooter,
+  CardDescription,
+} from "@/components/ui/card";
+import { useEditUserProfileForm } from "../hooks/useEditUserProfileForm";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/common/Skeleton";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { BioCounter } from "./BioCounter";
+import {
+  GitHubLogoIcon,
+  TwitterLogoIcon,
+  Link1Icon,
+} from "@radix-ui/react-icons";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+
+type EditUserProfileFormProps = {
+  user: User;
+};
+
+export const EditUserProfileForm: React.FC<EditUserProfileFormProps> = ({
+  user,
+}: EditUserProfileFormProps) => {
+  const { onSubmit, form } = useEditUserProfileForm(user);
+  const { isDirty, isSubmitting, isValid } = form.formState;
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <CardHeader>
+          <div className="flex items-center gap-4">
+            <Avatar className="h-16 w-16 border">
+              <AvatarImage src={user.icon} alt={user.name} />
+              <AvatarFallback>
+                <Skeleton className="h-16 w-16 rounded-full border" />
+              </AvatarFallback>
+            </Avatar>
+            <div className="flex flex-col gap-4 md:flex-row">
+              <FormField
+                control={form.control}
+                name="atcoderId"
+                render={({ field }) => (
+                  <FormItem className="flex flex-col">
+                    <FormLabel>AtCoder ID (required)</FormLabel>
+                    <FormControl>
+                      <Input
+                        className="md:w-72"
+                        type="text"
+                        placeholder="AtCoder ID"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem className="flex flex-col">
+                    <FormLabel>Name (required)</FormLabel>
+                    <FormControl>
+                      <Input
+                        className="md:w-72"
+                        type="text"
+                        placeholder="Name"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center">
+            <FormField
+              control={form.control}
+              name="occupation"
+              render={({ field }) => (
+                <FormItem className="flex flex-col">
+                  <FormLabel>Occupation</FormLabel>
+                  <FormControl>
+                    <Input
+                      className="md:w-64"
+                      type="text"
+                      placeholder="Occupation"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="organization"
+              render={({ field }) => (
+                <FormItem className="flex flex-col">
+                  <FormLabel>Organization</FormLabel>
+                  <FormControl>
+                    <Input
+                      className="md:w-64"
+                      type="text"
+                      placeholder="Organization"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+          <FormField
+            control={form.control}
+            name="bio"
+            render={({ field }) => (
+              <FormItem className="flex flex-col">
+                <FormLabel>Bio</FormLabel>
+                <FormControl>
+                  <Textarea placeholder="Bio" {...field} />
+                </FormControl>
+                <BioCounter control={form.control}>
+                  {(count) => (
+                    <CardDescription className="text-sm">
+                      {count}/{BIO_MAX_LENGTH}
+                    </CardDescription>
+                  )}
+                </BioCounter>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <div className="flex flex-col gap-4">
+            <FormField
+              control={form.control}
+              name="links.github"
+              render={({ field }) => (
+                <FormItem className="flex items-center gap-4">
+                  <GitHubLogoIcon className="h-6 w-6" />
+                  <FormControl>
+                    <Input
+                      className="w-72"
+                      type="text"
+                      placeholder="GitHub"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="links.twitter"
+              render={({ field }) => (
+                <FormItem className="flex items-center gap-4">
+                  <TwitterLogoIcon className="h-6 w-6" />
+                  <FormControl>
+                    <Input
+                      className="w-72"
+                      type="text"
+                      placeholder="Twitter"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="links.website"
+              render={({ field }) => (
+                <FormItem className="flex items-center gap-4">
+                  <Link1Icon className="h-6 w-6" />
+                  <FormControl>
+                    <Input
+                      className="w-72"
+                      type="text"
+                      placeholder="Website"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </CardContent>
+        <CardFooter>
+          <Button
+            type="submit"
+            className="ml-auto"
+            disabled={!isDirty || !isValid || isSubmitting}
+          >
+            Submit
+          </Button>
+        </CardFooter>
+      </form>
+    </Form>
+  );
+};

--- a/src/components/screen/UserProfileContent/hooks/useEditUserProfileForm.ts
+++ b/src/components/screen/UserProfileContent/hooks/useEditUserProfileForm.ts
@@ -8,13 +8,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { CLIENT_PATH } from "@/constants/clientpath";
 
 export const useEditUserProfileForm = (user: User) => {
-  const {
-    register,
-    handleSubmit,
-    control,
-    watch,
-    formState: { errors, isValid, isDirty, isSubmitting },
-  } = useForm<User>({
+  const form = useForm<User>({
     mode: "onChange",
     resolver: zodResolver(UserSchema),
     defaultValues: user,
@@ -34,13 +28,7 @@ export const useEditUserProfileForm = (user: User) => {
   };
 
   return {
-    register,
-    onSubmit: handleSubmit(onSubmit),
-    control,
-    watch,
-    errors,
-    isValid,
-    isDirty,
-    isSubmitting,
+    form,
+    onSubmit,
   };
 };

--- a/src/schema/User.type.ts
+++ b/src/schema/User.type.ts
@@ -8,9 +8,9 @@ export const OCCUPATION_MAX_LENGTH = 32;
 export const ORGANIZATION_MAX_LENGTH = 32;
 
 export const UserLinksSchema = z.object({
-  github: z.string().url({ message: "Invalid URL" }).nullable(),
-  twitter: z.string().url({ message: "Invalid URL" }).nullable(),
-  website: z.string().url({ message: "Invalid URL" }).nullable(),
+  github: z.string().url({ message: "Invalid URL" }).or(z.literal("")),
+  twitter: z.string().url({ message: "Invalid URL" }).or(z.literal("")),
+  website: z.string().url({ message: "Invalid URL" }).or(z.literal("")),
 });
 
 export const UserSchema = z.object({
@@ -28,24 +28,15 @@ export const UserSchema = z.object({
       message: charMaxLimitError("Name", NAME_MAX_LENGTH),
     }),
   icon: z.string(),
-  bio: z
-    .string()
-    .max(BIO_MAX_LENGTH, {
-      message: charMaxLimitError("Bio", BIO_MAX_LENGTH),
-    })
-    .nullable(),
-  occupation: z
-    .string()
-    .max(OCCUPATION_MAX_LENGTH, {
-      message: charMaxLimitError("Occupation", OCCUPATION_MAX_LENGTH),
-    })
-    .nullable(),
-  organization: z
-    .string()
-    .max(ORGANIZATION_MAX_LENGTH, {
-      message: charMaxLimitError("Organization", ORGANIZATION_MAX_LENGTH),
-    })
-    .nullable(),
+  bio: z.string().max(BIO_MAX_LENGTH, {
+    message: charMaxLimitError("Bio", BIO_MAX_LENGTH),
+  }),
+  occupation: z.string().max(OCCUPATION_MAX_LENGTH, {
+    message: charMaxLimitError("Occupation", OCCUPATION_MAX_LENGTH),
+  }),
+  organization: z.string().max(ORGANIZATION_MAX_LENGTH, {
+    message: charMaxLimitError("Organization", ORGANIZATION_MAX_LENGTH),
+  }),
   links: UserLinksSchema,
 });
 
@@ -60,8 +51,8 @@ export const INITIAL_USER: User = {
   occupation: "",
   organization: "",
   links: {
-    github: null,
-    twitter: null,
-    website: null,
+    github: "",
+    twitter: "",
+    website: "",
   },
 };


### PR DESCRIPTION
# what

- RHFをそのまま使っているFormに対して、shadcnのFormコンポーネントでリファクタした

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ユーザープロファイルの編集フォームを新しいコンポーネントに分離し、UIをシンプルにしました。

- **バグ修正**
  - ユーザーリンクのバリデーションロジックを修正し、空文字列を有効な値として受け入れるように変更しました。

- **リファクタリング**
  - ユーザープロファイル編集に関連する状態管理とフックを新しいフォームコンポーネントに移動しました。

- **その他の変更**
  - 必須フィールドの扱いを変更し、バイオ、職業、組織フィールドが必須になりました。
  - 初期ユーザーオブジェクトのソーシャルメディアフィールドのデフォルト値をnullから空文字列に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->