### PR TITLE
CIでキャッシュするように変更

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: Build
 on: pull_request
 
 jobs:
-  lint:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -11,6 +11,16 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
+
+      - name: Use GitHub Actions Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.npm
+            ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/bun.lockb') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/bun.lockb') }}-
 
       - name: Install dependencies
         run: bun install


### PR DESCRIPTION
# what

- GitHub Actionsでbuildをキャッシュするように修正

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **テスト**
	- GitHub Actionsのワークフロー名を `lint` から `test` に変更しました。
	- GitHub Actions キャッシュを利用する新しいステップを追加しました。キャッシュの設定には、`~/.npm` と `/.next/cache` ディレクトリのキャッシュが含まれており、特定のキーとリストアキーが定義されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->