### PR TITLE
チームを変更できるように修正

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,0 +1,13 @@
+const path = require("path");
+
+const buildEslintCommand = (filenames) =>
+  `next lint --fix --file ${filenames
+    .map((f) => path.relative(process.cwd(), f))
+    .join(" --file ")}`;
+
+const formatWithPrettier = (filenames) =>
+  `prettier --write --ignore-path .gitignore ${filenames.join(" ")}`;
+
+module.exports = {
+  "*.{js,jsx,ts,tsx}": [buildEslintCommand, formatWithPrettier],
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint --fix --ext .jsx,.js,.tsx,.ts .",
+    "lint": "next lint",
     "format": "prettier --write --ignore-path .gitignore './**/*.{js,jsx,ts,tsx,json}'",
     "prepare": "husky install"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "next lint --dir src",
     "format": "prettier --write --ignore-path .gitignore './**/*.{js,jsx,ts,tsx,json}'",
     "prepare": "husky install"
   },
@@ -71,11 +71,5 @@
     "react-chartjs-2": "^5.2.0",
     "tailwindcss": "^3.4.0",
     "typescript": "^5"
-  },
-  "lint-staged": {
-    "*.{ts,tsx}": [
-      "bun run format",
-      "bun run lint"
-    ]
   }
 }

--- a/src/features/battle/create/CreateBattleForm/ExpectedTeamContent/ExpectedTeamContent.tsx
+++ b/src/features/battle/create/CreateBattleForm/ExpectedTeamContent/ExpectedTeamContent.tsx
@@ -268,7 +268,7 @@ export const ExpectedTeamContent: React.FC<ExpectedTeamContentProps> = ({
         onClick={() => {
           const newExpectedTeams = [
             ...expectedTeams,
-            { name: "", members: [] },
+            { id: "", name: "", members: [] },
           ];
           setExpectedTeams(newExpectedTeams);
         }}

--- a/src/features/battle/detail/BattleDetailBoard/BattleDetailBoard.tsx
+++ b/src/features/battle/detail/BattleDetailBoard/BattleDetailBoard.tsx
@@ -9,11 +9,9 @@ import { TimeProgress } from "@/components/common/TimeProgress";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { createMockBattle } from "@/repositories/createMockBattle";
-import { createMockUsers } from "@/repositories/createMockUser";
 
 export const BattleDetailBoard = async () => {
   const battle = await createMockBattle({ variant: "running" });
-  const users = await createMockUsers(5);
 
   return (
     <div className="flex flex-col gap-8">
@@ -55,7 +53,9 @@ export const BattleDetailBoard = async () => {
       <Separator className="bg-gray-300" />
       <div className="flex gap-4">
         <Button variant="outline">Edit</Button>
-        <TeamJoinDialog users={users} />
+        <TeamJoinDialog>
+          <Button variant="outline">Join</Button>
+        </TeamJoinDialog>
         <TwitterShareButton
           url={`https://atcoder-team-battle.com/battle/${battle.id}`}
           text={`バーチャルコンテストに参加しよう！\nTitle: ${

--- a/src/features/battle/detail/BattleDetailBoard/BattleDetailTabs/StandingsTable/TeamScoreRow/TeamScoreRow.tsx
+++ b/src/features/battle/detail/BattleDetailBoard/BattleDetailTabs/StandingsTable/TeamScoreRow/TeamScoreRow.tsx
@@ -1,4 +1,9 @@
+import { Pencil2Icon } from "@radix-ui/react-icons";
+
+import { TeamJoinDialog } from "../../../TeamJoinDialog";
+
 import { UserAvatar } from "@/components/common/UserAvatar";
+import { Button } from "@/components/ui/button";
 import { TableRow, TableCell } from "@/components/ui/table";
 import { Team } from "@/schema/Team.type";
 import { User } from "@/schema/User.type";
@@ -39,6 +44,17 @@ export const TeamScoreRow: React.FC<TeamScoreRowProps> = ({
       <TableCell className="text-center">{index + 1}</TableCell>
       <TableCell>
         <div className="flex items-center justify-between gap-8">
+          <TeamJoinDialog defaultValues={teamScore.team}>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={(e) => {
+                e.stopPropagation();
+              }}
+            >
+              <Pencil2Icon />
+            </Button>
+          </TeamJoinDialog>
           <p className="whitespace-nowrap">{teamScore.team.name}</p>
           <div className="flex gap-4">
             {teamScore.team.members.map((member) => {

--- a/src/features/battle/detail/BattleDetailBoard/TeamJoinDialog/TeamJoinDialog.tsx
+++ b/src/features/battle/detail/BattleDetailBoard/TeamJoinDialog/TeamJoinDialog.tsx
@@ -25,25 +25,25 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { User } from "@/schema/User.type";
+import { Team } from "@/schema/Team.type";
 
 type TeamJoinDialogProps = {
-  users: User[];
+  defaultValues?: Team;
+  children: React.ReactNode;
 };
 
 export const TeamJoinDialog: React.FC<TeamJoinDialogProps> = ({
-  users,
+  defaultValues,
+  children,
 }: TeamJoinDialogProps) => {
-  const { onSubmit, form } = useSubmitTeamForm();
+  const { onSubmit, form, users } = useSubmitTeamForm({ defaultValues });
   const { isDirty, isSubmitting, isValid } = form.formState;
   const router = useRouter();
 
   return (
     <Dialog>
-      <DialogTrigger asChild>
-        <Button variant="outline">Join</Button>
-      </DialogTrigger>
-      <DialogContent>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent onClick={(e) => e.stopPropagation()}>
         <DialogHeader>
           <DialogTitle>Participate as a Team</DialogTitle>
           <DialogDescription>

--- a/src/features/battle/detail/BattleDetailBoard/TeamJoinDialog/hooks/useSubmitTeamForm.ts
+++ b/src/features/battle/detail/BattleDetailBoard/TeamJoinDialog/hooks/useSubmitTeamForm.ts
@@ -1,13 +1,22 @@
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useMemo } from "react";
 import { useForm } from "react-hook-form";
 
 import { useToast } from "@/components/ui/use-toast";
+import { createMockUsers } from "@/repositories/createMockUser";
 import { TeamSchema, Team } from "@/schema/Team.type";
 
-export const useSubmitTeamForm = () => {
+type useSubmitTeamFormProps = {
+  defaultValues?: Team;
+};
+
+export const useSubmitTeamForm = ({
+  defaultValues,
+}: useSubmitTeamFormProps) => {
   const form = useForm<Team>({
     mode: "onChange",
     resolver: zodResolver(TeamSchema),
+    defaultValues,
   });
 
   const { toast } = useToast();
@@ -20,8 +29,13 @@ export const useSubmitTeamForm = () => {
     });
   };
 
+  const users = useMemo(() => {
+    return createMockUsers(10);
+  }, []);
+
   return {
     form,
     onSubmit,
+    users,
   };
 };

--- a/src/repositories/createMockTeam.ts
+++ b/src/repositories/createMockTeam.ts
@@ -5,10 +5,12 @@ import { createMockUsers } from "./createMockUser";
 import { Team } from "@/schema/Team.type";
 
 export const createMockTeam = (): Team => {
+  const id = faker.string.uuid();
   const members = createMockUsers(Math.floor(Math.random() * 3) + 1);
   const name = faker.company.name();
 
   return {
+    id,
     name,
     members,
   };
@@ -16,12 +18,6 @@ export const createMockTeam = (): Team => {
 
 export const createMockTeams = (count: number): Team[] => {
   return Array.from({ length: count }, () => {
-    const members = createMockUsers(Math.floor(Math.random() * 3) + 1);
-    const name = faker.company.name();
-
-    return {
-      name,
-      members,
-    };
+    return createMockTeam();
   });
 };

--- a/src/schema/Team.type.ts
+++ b/src/schema/Team.type.ts
@@ -9,6 +9,7 @@ import {
 } from "@/utils/createErrors";
 
 export const TeamSchema = z.object({
+  id: z.string(),
   name: z
     .string()
     .min(1, { message: charMinLimitError("Name", 1) })


### PR DESCRIPTION
# what

- チームをバトル詳細から変更できるように修正

- 自分のチームのみ変更できるようにする機能と、idを正確なuuid生成を用いる部分は実装していない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ステージングされたファイルに対してESLintとPrettierを実行する設定を追加しました。
  - 期待されるチームの内容にIDフィールドを含むように更新しました。
  - "参加する"ボタンを含む新しいダイアログコンポーネントを追加しました。

- **バグ修正**
  - モックユーザーの生成を削除し、関連するコンポーネントの使用を更新しました。

- **改善点**
  - チーム参加ダイアログのプロパティを改善し、デフォルト値を設定できるようにしました。
  - チーム作成のフックを更新し、デフォルト値を受け取るようにしました。

- **リファクタリング**
  - モックチームの生成方法を再編成し、新しいID宣言を追加しました。

- **ドキュメント**
  - チームスキーマに新しいIDフィールドを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->