### PR TITLE
バトル作成フォームでカスタムコンポーネント側でvalueを受け取るように

### DIFF
--- a/src/components/common/ComboBox/hook/useComboBox.ts
+++ b/src/components/common/ComboBox/hook/useComboBox.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from "react";
 
-type useComboBoxProps = {
+type UseComboBoxProps = {
   options: {
     value: string;
     label: string;
@@ -8,7 +8,7 @@ type useComboBoxProps = {
   onChange?: (value: string) => void;
 };
 
-export const useComboBox = ({ options, onChange }: useComboBoxProps) => {
+export const useComboBox = ({ options, onChange }: UseComboBoxProps) => {
   const [open, setOpen] = useState<boolean>(false);
   const [value, setValue] = useState<string>("");
   const [keyword, setKeyword] = useState<string>("");

--- a/src/components/common/Flexbox/Flexbox.tsx
+++ b/src/components/common/Flexbox/Flexbox.tsx
@@ -1,24 +1,24 @@
 import { forwardRef, HTMLAttributes, ReactNode } from "react";
 
-type divProps = NonNullable<JSX.IntrinsicElements["div"]["style"]>;
+type DivProps = NonNullable<JSX.IntrinsicElements["div"]["style"]>;
 
 export type FlexboxProps = {
   children?: ReactNode;
-  margin?: divProps["margin"];
-  padding?: divProps["padding"];
-  flexDirection?: divProps["flexDirection"];
-  flexWrap?: divProps["flexWrap"];
-  justifyContent?: divProps["justifyContent"];
-  alignItems?: divProps["alignItems"];
-  alignContent?: divProps["alignContent"];
-  flexBasis?: divProps["flexBasis"];
-  flexGrow?: divProps["flexGrow"];
-  flexShrink?: divProps["flexShrink"];
-  width?: divProps["width"];
-  height?: divProps["height"];
-  overflow?: divProps["overflow"];
+  margin?: DivProps["margin"];
+  padding?: DivProps["padding"];
+  flexDirection?: DivProps["flexDirection"];
+  flexWrap?: DivProps["flexWrap"];
+  justifyContent?: DivProps["justifyContent"];
+  alignItems?: DivProps["alignItems"];
+  alignContent?: DivProps["alignContent"];
+  flexBasis?: DivProps["flexBasis"];
+  flexGrow?: DivProps["flexGrow"];
+  flexShrink?: DivProps["flexShrink"];
+  width?: DivProps["width"];
+  height?: DivProps["height"];
+  overflow?: DivProps["overflow"];
   style?: JSX.IntrinsicElements["div"]["style"];
-  gap?: divProps["gap"];
+  gap?: DivProps["gap"];
   className?: HTMLAttributes<HTMLLIElement>["className"];
 };
 

--- a/src/features/battle/BattleForm/BattleForm.tsx
+++ b/src/features/battle/BattleForm/BattleForm.tsx
@@ -85,11 +85,7 @@ export const BattleForm: React.FC<BattleFormProps> = ({
                   <FormItem className="flex flex-col">
                     <FormLabel>Description (required)</FormLabel>
                     <FormControl>
-                      <Textarea
-                        className="w-72"
-                        placeholder="Battle Description"
-                        {...field}
-                      />
+                      <Textarea placeholder="Battle Description" {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>

--- a/src/features/battle/BattleForm/ExpectedTeamContent/ExpectedTeamContent.tsx
+++ b/src/features/battle/BattleForm/ExpectedTeamContent/ExpectedTeamContent.tsx
@@ -32,12 +32,14 @@ type ExpectedTeamContentProps = {
   users: User[];
   onChange?: (teams: Score[]) => void;
   control: Control<Battle>;
+  value: Score[] | null;
 };
 
 export const ExpectedTeamContent: React.FC<ExpectedTeamContentProps> = ({
   users,
   onChange,
   control,
+  value,
 }: ExpectedTeamContentProps) => {
   const {
     expectedTeams,
@@ -50,7 +52,7 @@ export const ExpectedTeamContent: React.FC<ExpectedTeamContentProps> = ({
     ref,
     clickedTeamIndex,
     setClickedTeamIndex,
-  } = useExpectedTeamContent({ users });
+  } = useExpectedTeamContent({ users, value });
   const problems = useWatch({ name: "problems", control });
 
   useEffect(() => {
@@ -102,6 +104,7 @@ export const ExpectedTeamContent: React.FC<ExpectedTeamContentProps> = ({
                       <Input
                         placeholder="Team Name"
                         className="w-32 md:w-full"
+                        value={expectedTeam.name}
                         onChange={(e) => {
                           const newExpectedTeams = expectedTeams.map(
                             (expectedTeam, currentIndex) => {

--- a/src/features/battle/BattleForm/ExpectedTeamContent/hooks/useExpectedTeamContent.ts
+++ b/src/features/battle/BattleForm/ExpectedTeamContent/hooks/useExpectedTeamContent.ts
@@ -3,11 +3,22 @@
 import { useState, useRef, useMemo } from "react";
 import { useClickAway } from "react-use";
 
+import { Score } from "@/schema/Score.type";
 import { Team } from "@/schema/Team.type";
 import { User } from "@/schema/User.type";
 
-export const useExpectedTeamContent = ({ users }: { users: User[] }) => {
-  const [expectedTeams, setExpectedTeams] = useState<Team[]>([]);
+type UseExpectedTeamContentProps = {
+  users: User[];
+  value: Score[] | null;
+};
+
+export const useExpectedTeamContent = ({
+  users,
+  value,
+}: UseExpectedTeamContentProps) => {
+  const [expectedTeams, setExpectedTeams] = useState<Team[]>(
+    value ? value.map((score) => score.team) : [],
+  );
   const [keyword, setKeyword] = useState("");
   const [isSuggestionsOpen, setIsSuggestionsOpen] = useState(false);
   const [clickedTeamIndex, setClickedTeamIndex] = useState(-1);

--- a/src/features/battle/BattleForm/ProblemSetContent/ProblemSetContent.tsx
+++ b/src/features/battle/BattleForm/ProblemSetContent/ProblemSetContent.tsx
@@ -13,7 +13,7 @@ import { Problem } from "@/schema/Problem.type";
 type ProblemSetContentProps = {
   problems: Problem[];
   onChange?: (problems: Problem[]) => void;
-  value?: Problem[];
+  value: Problem[];
 };
 
 export const ProblemSetContent: React.FC<ProblemSetContentProps> = ({

--- a/src/features/battle/BattleForm/ProblemSetContent/ProblemSetContent.tsx
+++ b/src/features/battle/BattleForm/ProblemSetContent/ProblemSetContent.tsx
@@ -13,11 +13,13 @@ import { Problem } from "@/schema/Problem.type";
 type ProblemSetContentProps = {
   problems: Problem[];
   onChange?: (problems: Problem[]) => void;
+  value?: Problem[];
 };
 
 export const ProblemSetContent: React.FC<ProblemSetContentProps> = ({
   problems,
   onChange,
+  value,
 }: ProblemSetContentProps) => {
   const {
     isOpenSuggestedProblemList,
@@ -27,7 +29,7 @@ export const ProblemSetContent: React.FC<ProblemSetContentProps> = ({
     setSelectedProblems,
     suggestedProblems,
     openSuggestedProblemList,
-  } = useProblemSetContent({ problems });
+  } = useProblemSetContent({ problems, value });
 
   useEffect(() => {
     if (onChange) onChange(selectedProblems);

--- a/src/features/battle/BattleForm/ProblemSetContent/hooks/useProblemSetContent.ts
+++ b/src/features/battle/BattleForm/ProblemSetContent/hooks/useProblemSetContent.ts
@@ -4,7 +4,7 @@ import { Problem } from "@/schema/Problem.type";
 
 type UseProblemSetContentProps = {
   problems: Problem[];
-  value?: Problem[];
+  value: Problem[];
 };
 
 export const useProblemSetContent = ({
@@ -15,9 +15,7 @@ export const useProblemSetContent = ({
     useState(false);
   const [keyword, setKeyword] = useState("");
 
-  const [selectedProblems, setSelectedProblems] = useState<Problem[]>(
-    value || [],
-  );
+  const [selectedProblems, setSelectedProblems] = useState<Problem[]>(value);
 
   const suggestedProblems = useMemo(() => {
     if (keyword.length === 0) return [];

--- a/src/features/battle/BattleForm/ProblemSetContent/hooks/useProblemSetContent.ts
+++ b/src/features/battle/BattleForm/ProblemSetContent/hooks/useProblemSetContent.ts
@@ -2,7 +2,7 @@ import { useState, useMemo, useCallback, useEffect } from "react";
 
 import { Problem } from "@/schema/Problem.type";
 
-type useProblemSetContentProps = {
+type UseProblemSetContentProps = {
   problems: Problem[];
   value?: Problem[];
 };
@@ -10,7 +10,7 @@ type useProblemSetContentProps = {
 export const useProblemSetContent = ({
   problems,
   value,
-}: useProblemSetContentProps) => {
+}: UseProblemSetContentProps) => {
   const [isOpenSuggestedProblemList, setIsOpenSuggestedProblemList] =
     useState(false);
   const [keyword, setKeyword] = useState("");

--- a/src/features/battle/BattleForm/ProblemSetContent/hooks/useProblemSetContent.ts
+++ b/src/features/battle/BattleForm/ProblemSetContent/hooks/useProblemSetContent.ts
@@ -2,12 +2,22 @@ import { useState, useMemo, useCallback, useEffect } from "react";
 
 import { Problem } from "@/schema/Problem.type";
 
-export const useProblemSetContent = ({ problems }: { problems: Problem[] }) => {
+type useProblemSetContentProps = {
+  problems: Problem[];
+  value?: Problem[];
+};
+
+export const useProblemSetContent = ({
+  problems,
+  value,
+}: useProblemSetContentProps) => {
   const [isOpenSuggestedProblemList, setIsOpenSuggestedProblemList] =
     useState(false);
   const [keyword, setKeyword] = useState("");
 
-  const [selectedProblems, setSelectedProblems] = useState<Problem[]>([]);
+  const [selectedProblems, setSelectedProblems] = useState<Problem[]>(
+    value || [],
+  );
 
   const suggestedProblems = useMemo(() => {
     if (keyword.length === 0) return [];

--- a/src/features/battle/detail/BattleDetailBoard/TeamJoinDialog/hooks/useSubmitTeamForm.ts
+++ b/src/features/battle/detail/BattleDetailBoard/TeamJoinDialog/hooks/useSubmitTeamForm.ts
@@ -7,13 +7,13 @@ import { useToast } from "@/components/ui/use-toast";
 import { createMockUsers } from "@/repositories/createMockUser";
 import { TeamSchema, Team } from "@/schema/Team.type";
 
-type useSubmitTeamFormProps = {
+type UseSubmitTeamFormProps = {
   defaultValues?: Team;
 };
 
 export const useSubmitTeamForm = ({
   defaultValues,
-}: useSubmitTeamFormProps) => {
+}: UseSubmitTeamFormProps) => {
   const form = useForm<Team>({
     mode: "onChange",
     resolver: zodResolver(TeamSchema),


### PR DESCRIPTION
# what

- 問題追加とチーム追加のコンポーネントでvalueをつけとって、バトル編集時にデータが反映されるようにした

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- コンボボックスのプロップスの命名規則を改善しました。
	- フレックスボックスのスタイリングプロパティの型定義を更新しました。

- **改善点**
	- バトルフォームの記述入力フィールドの JSX 構造を簡素化しました。
	- 期待されるチームコンテンツに値プロップを受け取る機能を追加し、関連するフックを更新しました。
	- 問題セットコンテンツに値プロップを受け取る機能を追加し、関連するフックを更新しました。

- **バグ修正**
	- チーム参加ダイアログのフックで型定義の名前を修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->