### PR TITLE
チームダイアログの編集時に既存のチームメンバーを表示できるようにする

### DIFF
--- a/src/features/battle/detail/BattleDetailBoard/TeamJoinDialog/SelectMembers/SelectMembers.tsx
+++ b/src/features/battle/detail/BattleDetailBoard/TeamJoinDialog/SelectMembers/SelectMembers.tsx
@@ -10,13 +10,15 @@ import { User } from "@/schema/User.type";
 type SelectMembersProps = {
   users: User[];
   onChange: (users: User[]) => void;
+  value?: User[];
 };
 
 export const SelectMembers: React.FC<SelectMembersProps> = ({
   users,
   onChange,
+  value,
 }: SelectMembersProps) => {
-  const [selectedUsers, setSelectedUsers] = useState<User[]>([]);
+  const [selectedUsers, setSelectedUsers] = useState<User[]>(value || []);
   const selectUserOptions = useMemo(() => {
     return users
       .filter((user) => !selectedUsers.includes(user))


### PR DESCRIPTION
# what

- SelectMembersにvalue propsを与えることで、membersプロパティがすでに存在する場合にその値があらかじめ入るようにした

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - `SelectMembers` コンポーネントに新しいオプションの `value` プロパティを追加し、提供された場合に `selectedUsers` 状態を初期化できるようになりました。これにより、コンポーネントがレンダリングされたときにユーザーを事前に選択できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->