### PR TITLE
ユーザー関連のバトルページを作成

### DIFF
--- a/src/app/user/[userId]/battle/page.tsx
+++ b/src/app/user/[userId]/battle/page.tsx
@@ -1,0 +1,17 @@
+import { Metadata } from "next";
+import { Suspense } from "react";
+
+import { LoadingAlert } from "@/components/common/LoadingAlert";
+import { UserBattleContent } from "@/features/user/battle/UserBattleContent";
+
+export const metadata: Metadata = {
+  title: "Your Battle",
+};
+
+export default async function UserBattlePage() {
+  return (
+    <Suspense fallback={<LoadingAlert />}>
+      <UserBattleContent />
+    </Suspense>
+  );
+}

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -6,6 +6,7 @@ import {
   ChatBubbleIcon,
   HomeIcon,
   ExitIcon,
+  CookieIcon,
 } from "@radix-ui/react-icons";
 import Image from "next/image";
 import Link from "next/link";
@@ -98,11 +99,22 @@ export const Header: React.FC = () => {
                 className="flex gap-2"
               >
                 <PersonIcon />
-                Profile
+                Your Profile
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => {
+                  router.push(
+                    CLIENT_PATH.USER_BATTLE.replace("[userId]", "me"),
+                  );
+                }}
+                className="flex gap-2"
+              >
+                <CookieIcon />
+                Your Battle
               </DropdownMenuItem>
               <DropdownMenuItem className="flex gap-2">
                 <HomeIcon />
-                Team
+                Your Team
               </DropdownMenuItem>
               <DropdownMenuItem className="block sm:hidden">
                 <ThemeSwitch />

--- a/src/constants/clientpath.ts
+++ b/src/constants/clientpath.ts
@@ -5,6 +5,7 @@ export const CLIENT_PATH = {
   BATTLE_DETAIL: "/battle/detail/[battleId]",
   BATTLE_EDIT: "/battle/edit/[battleId]",
   USER: "/user/[userId]",
+  USER_BATTLE: "/user/[userId]/battle",
   USER_EDIT: "/user/[userId]/edit",
   NOT_FOUND: "/404",
 } as const;

--- a/src/features/user/UserProfileContent/UserProfileContent.tsx
+++ b/src/features/user/UserProfileContent/UserProfileContent.tsx
@@ -2,10 +2,6 @@ import { EditUserProfileCard } from "./EditUserProfileCard";
 import { UserProfileCard } from "./UserProfileCard";
 import { createMockUser } from "../../../repositories/createMockUser";
 
-import { NextArrow } from "@/components/common/NextArrow";
-import { BattleListTable } from "@/features/battle/main/BattleBoard/BattleLists/BattleListTable";
-import { createMockBattles } from "@/repositories/createMockBattle";
-
 type UserProfileContentProps = {
   isEdit?: boolean;
 };
@@ -14,11 +10,6 @@ export const UserProfileContent: React.FC<UserProfileContentProps> = async ({
   isEdit,
 }: UserProfileContentProps) => {
   const user = await createMockUser();
-  const joinedBattle = await createMockBattles({ count: 5, variant: "recent" });
-  const createdBattle = await createMockBattles({
-    count: 5,
-    variant: "recent",
-  });
 
   return (
     <div className="flex flex-col gap-8">
@@ -27,9 +18,6 @@ export const UserProfileContent: React.FC<UserProfileContentProps> = async ({
       ) : (
         <UserProfileCard user={user} />
       )}
-      <BattleListTable battles={joinedBattle} title="Joined Battles" />
-      <NextArrow className="my-8" />
-      <BattleListTable battles={createdBattle} title="Created Battles" />
     </div>
   );
 };

--- a/src/features/user/battle/UserBattleContent/UserBattleContent.tsx
+++ b/src/features/user/battle/UserBattleContent/UserBattleContent.tsx
@@ -1,0 +1,19 @@
+import { NextArrow } from "@/components/common/NextArrow";
+import { BattleListTable } from "@/features/battle/main/BattleBoard/BattleLists/BattleListTable";
+import { createMockBattles } from "@/repositories/createMockBattle";
+
+export const UserBattleContent = async () => {
+  const joinedBattle = await createMockBattles({ count: 5, variant: "recent" });
+  const createdBattle = await createMockBattles({
+    count: 5,
+    variant: "recent",
+  });
+
+  return (
+    <div>
+      <BattleListTable battles={joinedBattle} title="Joined Battles" />
+      <NextArrow className="my-8" />
+      <BattleListTable battles={createdBattle} title="Created Battles" />
+    </div>
+  );
+};

--- a/src/features/user/battle/UserBattleContent/index.ts
+++ b/src/features/user/battle/UserBattleContent/index.ts
@@ -1,0 +1,1 @@
+export { UserBattleContent } from "./UserBattleContent";


### PR DESCRIPTION
resolve #55 

# what

- ユーザーに関連するバトルはユーザープロファイルのページにあったが、それを別ページに切り分けた

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ユーザーのバトルページコンポーネントを追加し、ローディング時の表示も実装。
	- ヘッダーコンポーネントに「クッキーアイコン」を追加し、ドロップダウンメニューの項目を更新。
	- 新しいユーザーバトルのパスを定数に追加。

- **機能改善**
	- ユーザープロファイルコンテンツから不要なインポートと非同期モックバトル生成処理を削除。
	- ユーザーバトルコンテンツに参加中および作成したバトルを非同期で取得し、表形式で表示する新コンポーネントを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->