### PR TITLE
アイコン付きセパレーターの実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --turbo",
     "build": "next build",
     "start": "next start",
     "lint": "next lint --dir src",

--- a/src/components/common/SeparatorIcon/SeparatorIcon.tsx
+++ b/src/components/common/SeparatorIcon/SeparatorIcon.tsx
@@ -1,0 +1,17 @@
+type SeparatorIconProps = {
+  icon: React.ReactNode;
+  text: string;
+};
+
+export const SeparatorIcon: React.FC<SeparatorIconProps> = ({
+  icon,
+  text,
+}: SeparatorIconProps) => {
+  return (
+    <div className="my-8 flex animate-bounce items-center justify-center gap-2">
+      <div>{icon}</div>
+      <p>{text}</p>
+      <div>{icon}</div>
+    </div>
+  );
+};

--- a/src/components/common/SeparatorIcon/index.ts
+++ b/src/components/common/SeparatorIcon/index.ts
@@ -1,0 +1,1 @@
+export { SeparatorIcon } from "./SeparatorIcon";

--- a/src/features/battle/main/BattleBoard/BattleLists/BattleLists.tsx
+++ b/src/features/battle/main/BattleBoard/BattleLists/BattleLists.tsx
@@ -1,7 +1,9 @@
+import { RocketIcon } from "lucide-react";
+
 import { BattleListTable } from "./BattleListTable";
 import { CreateBattleButton } from "../CreateBattleButton";
 
-import { NextArrow } from "@/components/common/NextArrow";
+import { SeparatorIcon } from "@/components/common/SeparatorIcon";
 import { Battle } from "@/schema/Battle.type";
 
 type BattleListsProps = {
@@ -19,9 +21,9 @@ export const BattleLists: React.FC<BattleListsProps> = ({
     <div className="flex flex-col gap-4">
       <CreateBattleButton />
       <BattleListTable battles={runningBattles} title="Running Battles" />
-      <NextArrow className="my-8" />
+      <SeparatorIcon text="Let's Battle!" icon={<RocketIcon />} />
       <BattleListTable battles={upcomingBattles} title="Upcoming Battles" />
-      <NextArrow className="my-8" />
+      <SeparatorIcon text="Let's Battle!" icon={<RocketIcon />} />
       <BattleListTable battles={recentBattles} title="Recent Battles" />
     </div>
   );

--- a/src/features/user/battle/UserBattleContent/UserBattleContent.tsx
+++ b/src/features/user/battle/UserBattleContent/UserBattleContent.tsx
@@ -1,4 +1,6 @@
-import { NextArrow } from "@/components/common/NextArrow";
+import { RocketIcon } from "lucide-react";
+
+import { SeparatorIcon } from "@/components/common/SeparatorIcon";
 import { BattleListTable } from "@/features/battle/main/BattleBoard/BattleLists/BattleListTable";
 import { createMockBattles } from "@/repositories/createMockBattle";
 
@@ -15,7 +17,7 @@ export const UserBattleContent = async () => {
   return (
     <div>
       <BattleListTable battles={joinedBattles} title="Joined Battles" />
-      <NextArrow className="my-8" />
+      <SeparatorIcon text="Let's Battle!" icon={<RocketIcon />} />
       <BattleListTable battles={createdBattles} title="Created Battles" />
     </div>
   );


### PR DESCRIPTION
## 概要

- Battle一覧の間にあった矢印が、テーブルを拡大するものと見間違いそうなので、明確な区切りを実装したかった
- アイコンが両端にあるseparatorを実装した


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - バウンスアニメーション付きのアイコンとテキストを表示する`SeparatorIcon`コンポーネントを追加しました。
  
- **機能改善**
  - バトルカテゴリ間の視覚的な区切りとして、`NextArrow`コンポーネントを`SeparatorIcon`コンポーネントに置き換え、"Let's Battle!"のテキストとロケットアイコンを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->