### PR TITLE
データテーブルの表示設定を追加

### DIFF
--- a/src/components/common/DataTable/DataTable.tsx
+++ b/src/components/common/DataTable/DataTable.tsx
@@ -12,10 +12,8 @@ import {
 import {
   SortableContext,
   verticalListSortingStrategy,
-  useSortable,
   arrayMove,
 } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
 import {
   ArrowLeftIcon,
   ArrowRightIcon,
@@ -31,9 +29,10 @@ import {
   getPaginationRowModel,
   ColumnDef,
   SortingState,
-  Row,
 } from "@tanstack/react-table";
 import { useState } from "react";
+
+import { SortableDataTableRow } from "./SortableDataTableRow";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -59,41 +58,6 @@ type DataTableProps<T> = {
   onRowClick?: (id: T) => void;
   draggable?: boolean;
   setData?: (data: T[]) => void;
-};
-
-type DataTableRowProps<T> = {
-  row: Row<T>;
-  onRowClick?: (id: T) => void;
-};
-
-const SortableDataTableRow = <T,>({
-  row,
-  onRowClick,
-}: DataTableRowProps<T>) => {
-  const { attributes, listeners, setNodeRef, transform, transition } =
-    useSortable({
-      id: row.id,
-    });
-
-  return (
-    <TableRow
-      key={row.id}
-      className="cursor-pointer hover:bg-gray-800/10"
-      onClick={() => {
-        if (onRowClick) onRowClick(row.original);
-      }}
-      ref={setNodeRef}
-      style={{ transform: CSS.Transform.toString(transform), transition }}
-      {...attributes}
-      {...listeners}
-    >
-      {row.getVisibleCells().map((cell) => (
-        <TableCell key={cell.id}>
-          {flexRender(cell.column.columnDef.cell, cell.getContext())}
-        </TableCell>
-      ))}
-    </TableRow>
-  );
 };
 
 export const DataTable = <T,>({

--- a/src/components/common/DataTable/SortableDataTableRow/SortableDataTableRow.tsx
+++ b/src/components/common/DataTable/SortableDataTableRow/SortableDataTableRow.tsx
@@ -1,0 +1,40 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { Row, flexRender } from "@tanstack/react-table";
+
+import { TableRow, TableCell } from "@/components/ui/table";
+
+type DataTableRowProps<T> = {
+  row: Row<T>;
+  onRowClick?: (id: T) => void;
+};
+
+export const SortableDataTableRow = <T,>({
+  row,
+  onRowClick,
+}: DataTableRowProps<T>) => {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({
+      id: row.id,
+    });
+
+  return (
+    <TableRow
+      key={row.id}
+      className="cursor-pointer hover:bg-gray-800/10"
+      onClick={() => {
+        if (onRowClick) onRowClick(row.original);
+      }}
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      {...attributes}
+      {...listeners}
+    >
+      {row.getVisibleCells().map((cell) => (
+        <TableCell key={cell.id}>
+          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+        </TableCell>
+      ))}
+    </TableRow>
+  );
+};

--- a/src/components/common/DataTable/SortableDataTableRow/index.ts
+++ b/src/components/common/DataTable/SortableDataTableRow/index.ts
@@ -1,0 +1,1 @@
+export { SortableDataTableRow } from "./SortableDataTableRow";


### PR DESCRIPTION
## 概要

- テーブルの表示設定として、普通かページネーションか仮想テーブルかを選択できるようにした
- データテーブルの子要素をコンポーネントとして切り分けた


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- データテーブルの行のドラッグアンドドロップによる並び替え機能を追加しました。
	- 行をクリックした際のイベントを処理するためのコールバック機能を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->